### PR TITLE
Switch to https for maven repo

### DIFF
--- a/projects/index.adoc
+++ b/projects/index.adoc
@@ -31,42 +31,42 @@
 
 |https://github.com/smallrye/smallrye-config[Config]
 |1.3
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-config/1.3.5/smallrye-config-1.3.5.jar[1.3.5]
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-config/1.4.1/smallrye-config-1.4.1.jar[1.4.1]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-config/1.3.5/smallrye-config-1.3.5.jar[1.3.5]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-config/1.4.1/smallrye-config-1.4.1.jar[1.4.1]
 
 |https://github.com/smallrye/smallrye-fault-tolerance[Fault Tolerance]
 |2.0.2
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-fault-tolerance/2.0.0/smallrye-fault-tolerance-2.0.0.jar[2.0.0]
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-fault-tolerance/2.1.2/smallrye-fault-tolerance-2.1.2.jar[2.1.2]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-fault-tolerance/2.0.0/smallrye-fault-tolerance-2.0.0.jar[2.0.0]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-fault-tolerance/2.1.2/smallrye-fault-tolerance-2.1.2.jar[2.1.2]
 
 |https://github.com/smallrye/smallrye-health[Health]
 |1.0 / 2.1
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-health/1.0.2/smallrye-health-1.0.2.jar[1.0.2]
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-health/2.1.0/smallrye-health-2.1.0.jar[2.1.0]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-health/1.0.2/smallrye-health-1.0.2.jar[1.0.2]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-health/2.1.0/smallrye-health-2.1.0.jar[2.1.0]
 
 |https://github.com/smallrye/smallrye-jwt[JWT]
 |1.1.1
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-jwt/1.1.1/smallrye-jwt-1.1.1.jar[1.1.1]
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-jwt/2.0.10/smallrye-jwt-2.0.10.jar[2.0.10]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-jwt/1.1.1/smallrye-jwt-1.1.1.jar[1.1.1]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-jwt/2.0.10/smallrye-jwt-2.0.10.jar[2.0.10]
 
 |https://github.com/smallrye/smallrye-metrics[Metrics]
 |1.1 / 2.2
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-metrics/1.1.3/smallrye-metrics-1.1.3.jar[1.1.3]
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-metrics/2.3.0/smallrye-metrics-2.3.0.jar[2.3.0]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-metrics/1.1.3/smallrye-metrics-1.1.3.jar[1.1.3]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-metrics/2.3.0/smallrye-metrics-2.3.0.jar[2.3.0]
 
 |https://github.com/smallrye/smallrye-open-api[OpenAPI]
 |1.1.2
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-open-api/1.1.1/smallrye-open-api-1.1.1.jar[1.1.1]
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-open-api/1.1.19/smallrye-open-api-1.1.19.jar[1.1.19]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-open-api/1.1.1/smallrye-open-api-1.1.1.jar[1.1.1]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-open-api/1.1.19/smallrye-open-api-1.1.19.jar[1.1.19]
 
 |https://github.com/smallrye/smallrye-opentracing[OpenTracing]
 |1.3.1
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-opentracing/1.3.0/smallrye-opentracing-1.3.0.jar[1.3.0]
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-opentracing/1.3.2/smallrye-opentracing-1.3.2.jar[1.3.2]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-opentracing/1.3.0/smallrye-opentracing-1.3.0.jar[1.3.0]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-opentracing/1.3.2/smallrye-opentracing-1.3.2.jar[1.3.2]
 
 |https://github.com/resteasy/Resteasy/tree/master/resteasy-client-microprofile[REST Client]
 |1.2.1 / 1.3.4
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-rest-client/1.2.1/smallrye-rest-client-1.2.1.jar[1.2.1 (SmallRye)]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-rest-client/1.2.1/smallrye-rest-client-1.2.1.jar[1.2.1 (SmallRye)]
 |https://repo1.maven.org/maven2/org/jboss/resteasy/resteasy-client-microprofile/4.4.0.Final/resteasy-client-microprofile-4.4.0.Final.jar[4.4.0.Final]
 |===
 
@@ -81,7 +81,7 @@
 
 |https://github.com/smallrye/smallrye-context-propagation[Context Propagation]
 |1.0
-|http://repo1.maven.org/maven2/io/smallrye/smallrye-context-propagation/1.0.11/smallrye-context-propagation-1.0.11.jar[1.0.11]
+|https://repo1.maven.org/maven2/io/smallrye/smallrye-context-propagation/1.0.11/smallrye-context-propagation-1.0.11.jar[1.0.11]
 
 |https://github.com/smallrye/smallrye-reactive-messaging[Reactive Messaging]
 |1.0


### PR DESCRIPTION
As of January 15, 2020, the maven central repo does not allow for http connections.  All connections must be made with https or will receive a 501 error.