### PR TITLE
Include documentation of SmallRye projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-metadata
 .DS_Store
 .idea
+docs/build

--- a/README.md
+++ b/README.md
@@ -35,8 +35,21 @@ These instructions will get you a copy of the SmallRye.io website up and running
 or the [requirements](https://jekyllrb.com/docs/installation/#requirements) page,
 as you might be missing development headers or other prerequisites.
 
-
 **For more regarding the use of Jekyll, please refer to the [Jekyll Step by Step Tutorial](https://jekyllrb.com/docs/step-by-step/01-setup/).**
+
+### Building the documentation
+
+Documentation of SmallRye projects is built separately, because it's not using Jekyll. Instead, it's using Antora.
+
+1. Install Antora. See [Antora installation](https://docs.antora.org/antora/2.0/install/install-antora/).
+
+2. Go to the `docs` directory and run
+
+	antora generate antora-playbook.yml --fetch
+
+3. Now you should have the html files for SmallRye documentation in the `docs/build/site` directory. Make sure you're viewing these files directly rather than through Jekyll - explanation is in the following paragraph.
+
+There is a caveat in using Antora together with GitHub Pages, because GitHub Pages runs all files in the repository through Jekyll, which breaks Antora's directory structure. To prevent this, before committing the documentation site to a GitHub Pages repository, create an empty file named `.nojekyll` in the root of the repository. See [Antora documentation](https://docs.antora.org/antora/2.2/run-antora/#publish-to-github-pages) for more information.
 
 ## Contributing
 

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ exclude:
   - LICENSE
   - README.md
   - .idea
+  - docs
 #   - node_modules
 #   - vendor/bundle/
 #   - vendor/cache/

--- a/_includes/header-navigation.html
+++ b/_includes/header-navigation.html
@@ -17,6 +17,9 @@
             <li>
               <a href="{{site.baseurl}}/blog/" class="{% if page.url contains '/blog/' %}active{% endif %}">Blog</a>
             </li>
+            <li>
+              <a href="{{site.baseurl}}/docs/index.html" class="{% if page.url contains '/docs/' %}active{% endif %}">Documentation</a>
+            </li>
           </ul>
         </nav>
       </div>

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -1,0 +1,28 @@
+site:
+  title: SmallRye documentation
+  start_page: index::index.adoc
+content:
+  sources:
+  - url: .. # common module containing just the main index
+    start_path: docs
+    branches: HEAD
+  - url: https://github.com/smallrye/smallrye-metrics.git
+    branches: 2.4.x
+    start_path: doc
+# uncomment after the docs are merged    
+#  - url: https://github.com/smallrye/smallrye-reactive-messaging.git
+#    branches: master
+#    start_path: doc
+ui:
+  bundle:
+    url: https://github.com/smallrye/smallrye-antora-ui/blob/master/build/ui-bundle.zip?raw=true
+    snapshot: true
+# FIXME: These are variables used in the Reactive Messaging documentation. Antora 2.2 does not support
+# defining them in a component descriptor, so we keep them here temporarily.
+# After Antora 2.3.0 is released, move this to the component descriptor
+asciidoc:
+  attributes:
+    version: '1.1.0'
+    weld-version: '3.1.3.Final'
+    smallrye-streams-version: '1.0.10'
+    smallrye-config-version: '1.6.2'

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,0 +1,4 @@
+# Descriptor of the common Antora module that contains just a landing page for the whole documentation site
+name: index
+title: Index
+version: index

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,0 +1,6 @@
+= SmallRye documentation
+
+Welcome to the SmallRye documentation site. Pick the project you're interested in from the list below.
+
+* xref:smallrye-metrics:ROOT:index.adoc[SmallRye Metrics]
+// * xref:smallrye-reactive-messaging:ROOT:index.adoc[SmallRye Reactive Messaging]


### PR DESCRIPTION
Sneak peek. Includes some basic docs for Metrics 2.4.0 only so far.
Resulting page looks like this https://jmartisk.github.io/smallrye.github.io - click the "documentation" link in the top right corner (including the link there is just my idea, it can be somewhere else)

Draft documentation of the process: https://github.com/smallrye/smallrye-parent/wiki/(DRAFT)-SmallRye-documentation-process

If this gets positive feedback... then before we merge this, we need to
- move the https://github.com/jmartisk/smallrye-antora-ui repo under SmallRye org
- update the references to the UI bundle so that it will be taken from the new repo under SmallRye org
- merge the https://github.com/jmartisk/smallrye-metrics/tree/2.4.x-docs branch into the official metrics repo and make the `antora-playbook.yml` file reference that instead of my own repo
- same as above for Reactive Messaging
- update the Semaphore deployment job so that the Antora site gets built and pushed into master together with the rest of the website. I have that already working on my fork. 
- fix links in the documentation process wiki page to their permanent versions
- optionally determine how to improve the UI look, I did a few basic changes, but it's still somewhat ugly. I'm not a graphic designer at all, so looking for volunteers :)
- determine what should be used for the default index page when a user clicks the "documentation" link on the website

after merging:
- integrate docs from as many other SmallRye projects as we can