### PR TITLE
Remove variables from playbook while updating to Antora 2.3

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -17,12 +17,3 @@ ui:
   bundle:
     url: https://github.com/smallrye/smallrye-antora-ui/blob/master/build/ui-bundle.zip?raw=true
     snapshot: true
-# FIXME: These are variables used in the Reactive Messaging documentation. Antora 2.2 does not support
-# defining them in a component descriptor, so we keep them here temporarily.
-# After Antora 2.3.0 is released, move this to the component descriptor
-asciidoc:
-  attributes:
-    version: '1.1.0'
-    weld-version: '3.1.3.Final'
-    smallrye-streams-version: '1.0.10'
-    smallrye-config-version: '1.6.2'


### PR DESCRIPTION
Antora `2.3.0-beta.1` was released this weekend and it comes with support for keeping variables in the component descriptors (`antora.yml`) so we can clean up variables from the main playbook. We weren't using any variables yet anyway, so this basically does not change anything. From now on, if a SmallRye project needs to use variables in their docs, it will be in their own `antora.yml` descriptor rather than the global playbook.
I already updated the semaphore job to use Antora `2.3.0-beta.1`