### PR TITLE
Added SmallRye JWT documentation.

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -9,6 +9,9 @@ content:
   - url: https://github.com/smallrye/smallrye-config.git
     branches: master
     start_path: doc
+  - url: https://github.com/smallrye/smallrye-jwt.git
+    branches: master
+    start_path: doc
   - url: https://github.com/smallrye/smallrye-metrics.git
     branches: 2.4.x
     start_path: doc

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -3,5 +3,6 @@
 Welcome to the SmallRye documentation site. Pick the project you're interested in from the list below.
 
 * xref:smallrye-config:ROOT:index.adoc[SmallRye Config]
+* xref:smallrye-jwt:ROOT:index.adoc[SmallRye JWT]
 * xref:smallrye-metrics:ROOT:index.adoc[SmallRye Metrics]
 // * xref:smallrye-reactive-messaging:ROOT:index.adoc[SmallRye Reactive Messaging]


### PR DESCRIPTION
Requires https://github.com/smallrye/smallrye-jwt/pull/219 merged first.