### PR TITLE
Ignore node.js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _site
 .DS_Store
 .idea
 docs/build
+node_modules
+package-lock.json


### PR DESCRIPTION
if someone installs Antora into their local copy, these files should be ignored