### PR TITLE
Update metrics branch, former master is now 3.0.x

### DIFF
--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -13,7 +13,7 @@ content:
     branches: master
     start_path: doc
   - url: https://github.com/smallrye/smallrye-metrics.git
-    branches: [2.4.x, master]
+    branches: [2.4.x, 3.0.x]
     start_path: doc
   - url: https://github.com/smallrye/smallrye-fault-tolerance.git
     branches: ~


### PR DESCRIPTION
In SR Metrics, the former master is now 3.0.x, the former `micrometer` branch is now `main` (we don't have any docs relevant to that branch yet)